### PR TITLE
[feature/#9] 기본 Controller, Service 작성 및 ajax 연결

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# to2.kr
+# [to2.kr](https://to2.kr)
 
 주소를 짧게 줄여주는 서비스
 
-## External Application Configuration
+**기존 PHP로 만들어진 서비스를 Java Spring으로 마이그레이션 중**
+
+## 설정
+
+### External Application Configuration
 
 소스코드 내부에 민감정보를 포함시키지 않기 위해서 [features.external-config.files.wildcard-locations](https://docs.spring.io/spring-boot/docs/2.5.x/reference/html/features.html#features.external-config.files.wildcard-locations) 기능을 사용하여 설정을 관리합니다.
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,5 +15,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+  implementation 'org.springframework.boot:spring-boot-starter-validation'
+
   runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.4'
 }

--- a/src/main/java/kr/to2/config/RecaptchaProperties.java
+++ b/src/main/java/kr/to2/config/RecaptchaProperties.java
@@ -5,6 +5,7 @@ import javax.annotation.PostConstruct;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import kr.to2.util.Strings;
 import lombok.Data;
 
 @Data
@@ -18,13 +19,9 @@ public class RecaptchaProperties {
   @PostConstruct
   private void postConstruct() {
     if (this.active) {
-      if (isEmptyString(this.siteKey) || isEmptyString(this.privateKey)) {
+      if (Strings.isEmptyString(this.siteKey) || Strings.isEmptyString(this.privateKey)) {
         throw new RuntimeException("recaptcha.siteKey 또는 recaptcha.privateKey가 필요합니다.");
       }
     }
-  }
-
-  private static boolean isEmptyString(String string) {
-    return string == null || string.isBlank();
   }
 }

--- a/src/main/java/kr/to2/controller/To2Controller.java
+++ b/src/main/java/kr/to2/controller/To2Controller.java
@@ -1,13 +1,37 @@
 package kr.to2.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
 
+import kr.to2.dto.to2.ShortenRequest;
+import kr.to2.dto.to2.ShortenResponse;
+import kr.to2.service.RecaptchaService;
+import kr.to2.service.To2Service;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 @Controller("/")
 public class To2Controller {
+
+  private To2Service to2Service;
+  private RecaptchaService recaptchaService;
   
   @GetMapping()
   public String index() {
     return "index";
   }
+
+  @ResponseBody
+  @PostMapping("/shorten")
+  public ShortenResponse shorten(@Valid @RequestBody ShortenRequest shortenRequest) {
+    this.recaptchaService.verify(shortenRequest.getRecaptcha());
+    final String shorenUrl = this.to2Service.shorten(shortenRequest.getUrl());
+    return ShortenResponse.builder().shortenUrl(shorenUrl).build();
+  }
+
 }

--- a/src/main/java/kr/to2/controller/To2Controller.java
+++ b/src/main/java/kr/to2/controller/To2Controller.java
@@ -2,17 +2,21 @@ package kr.to2.controller;
 
 import javax.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.view.RedirectView;
 
 import kr.to2.dto.to2.ShortenRequest;
 import kr.to2.dto.to2.ShortenResponse;
 import kr.to2.service.RecaptchaService;
 import kr.to2.service.To2Service;
 import lombok.AllArgsConstructor;
+
 
 @AllArgsConstructor
 @Controller("/")
@@ -34,4 +38,14 @@ public class To2Controller {
     return ShortenResponse.builder().shortenUrl(shorenUrl).build();
   }
 
+  @ResponseBody
+  @GetMapping("/{code:" + To2Service.CODE_REGEX + "}")
+  public RedirectView code(@PathVariable String code) {
+    final String url = this.to2Service.findUrlFromCode(code);
+
+    final RedirectView redirectView = new RedirectView(url);
+    redirectView.setStatusCode(HttpStatus.MOVED_PERMANENTLY);
+    return redirectView;
+  }
+  
 }

--- a/src/main/java/kr/to2/dto/ApiResponseType.java
+++ b/src/main/java/kr/to2/dto/ApiResponseType.java
@@ -1,0 +1,25 @@
+package kr.to2.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+/*
+오류  |  Cloud API  |  Google Cloud (오류 처리)
+https://cloud.google.com/apis/design/errors#handling_errors
+를 참고해서 작성
+*/
+
+public enum ApiResponseType {
+
+  OK(HttpStatus.OK),
+  INVALID_ARGUMENT(HttpStatus.BAD_REQUEST);
+
+  @Getter
+  private final HttpStatus status;
+  
+  private ApiResponseType(HttpStatus status) {
+    this.status = status;
+  }
+
+}

--- a/src/main/java/kr/to2/dto/to2/ShortenRequest.java
+++ b/src/main/java/kr/to2/dto/to2/ShortenRequest.java
@@ -1,0 +1,15 @@
+package kr.to2.dto.to2;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Data;
+
+@Data
+public class ShortenRequest {
+
+  @NotBlank
+  private String url;
+
+  private String recaptcha;
+  
+}

--- a/src/main/java/kr/to2/dto/to2/ShortenResponse.java
+++ b/src/main/java/kr/to2/dto/to2/ShortenResponse.java
@@ -1,0 +1,12 @@
+package kr.to2.dto.to2;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ShortenResponse {
+  
+  private String shortenUrl;
+
+}

--- a/src/main/java/kr/to2/error/ApiErrorCode.java
+++ b/src/main/java/kr/to2/error/ApiErrorCode.java
@@ -1,0 +1,18 @@
+package kr.to2.error;
+
+import kr.to2.dto.ApiResponseType;
+import lombok.Getter;
+
+
+public enum ApiErrorCode {
+
+  // TODO: 추후 DDD로 변경시 모두 분리 관리
+  RECAPTCHA_INVALID(ApiResponseType.INVALID_ARGUMENT);
+
+  @Getter
+  private final ApiResponseType type;
+
+  private ApiErrorCode(ApiResponseType type) {
+    this.type = type;
+  }
+}

--- a/src/main/java/kr/to2/error/ApiException.java
+++ b/src/main/java/kr/to2/error/ApiException.java
@@ -1,0 +1,15 @@
+package kr.to2.error;
+
+import lombok.Getter;
+
+public class ApiException extends RuntimeException {
+
+  @Getter
+  private ApiErrorCode code;
+
+  public ApiException(ApiErrorCode code, String message) {
+    super(message);
+    this.code = code;
+  }
+  
+}

--- a/src/main/java/kr/to2/service/RecaptchaService.java
+++ b/src/main/java/kr/to2/service/RecaptchaService.java
@@ -1,0 +1,8 @@
+package kr.to2.service;
+
+// for 'Service Sub'
+public interface RecaptchaService {
+
+  void verify(String recaptcah);
+  
+}

--- a/src/main/java/kr/to2/service/RecaptchaServiceImpl.java
+++ b/src/main/java/kr/to2/service/RecaptchaServiceImpl.java
@@ -1,0 +1,28 @@
+package kr.to2.service;
+
+import org.springframework.stereotype.Service;
+
+import kr.to2.config.RecaptchaProperties;
+import kr.to2.error.ApiErrorCode;
+import kr.to2.error.ApiException;
+import kr.to2.util.Strings;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@Service
+public class RecaptchaServiceImpl implements RecaptchaService {
+
+  private RecaptchaProperties recaptchaProperties;
+
+  @Override
+  public void verify(String recaptcha) {
+    if (this.recaptchaProperties.isActive()) {
+      if (Strings.isEmptyString(recaptcha)) {
+        throw new ApiException(ApiErrorCode.RECAPTCHA_INVALID, "recaptcha 정보가 없습니다.");
+      }
+
+      // TODO: 실제 recaptcah 검증과 연결
+    }
+  }
+  
+}

--- a/src/main/java/kr/to2/service/To2Service.java
+++ b/src/main/java/kr/to2/service/To2Service.java
@@ -1,0 +1,18 @@
+package kr.to2.service;
+
+// for 'Service Sub'
+public interface To2Service {
+
+  static final char[] CODES = new char[] {
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'm', 'n',
+    'o','p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L','M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    '1', '2', '3', '4', '5', '6', '7', '8', '9'
+  };
+
+  String shorten(String url);
+
+  String findUrlFromCode(String code);
+
+}

--- a/src/main/java/kr/to2/service/To2Service.java
+++ b/src/main/java/kr/to2/service/To2Service.java
@@ -3,6 +3,8 @@ package kr.to2.service;
 // for 'Service Sub'
 public interface To2Service {
 
+  static final String CODE_REGEX = "[abcdefghjkmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789]{3,}";
+
   static final char[] CODES = new char[] {
     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'm', 'n',
     'o','p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',

--- a/src/main/java/kr/to2/service/To2ServiceImpl.java
+++ b/src/main/java/kr/to2/service/To2ServiceImpl.java
@@ -1,0 +1,20 @@
+package kr.to2.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class To2ServiceImpl implements To2Service {
+
+  @Override
+  public String shorten(String url) {
+    // TODO: 실제 Model 처리 로직으로 변경
+    return "https://to2.kr/aaa";
+  }
+
+  @Override
+  public String findUrlFromCode(String code) {
+    // TODO: 실제 Model 처리 로직으로 변경
+    return "https://github.com/Team-ZeroHouse/to2.kr-server";
+  }
+  
+}

--- a/src/main/java/kr/to2/util/Strings.java
+++ b/src/main/java/kr/to2/util/Strings.java
@@ -1,0 +1,9 @@
+package kr.to2.util;
+
+public final class Strings {
+
+  public static boolean isEmptyString(String string) {
+    return string == null || string.isBlank();
+  }
+  
+}

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -8,6 +8,7 @@
     '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
     '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
 
+  // polyfill
   Number.isInteger = Number.isInteger || function(value) {
     return typeof value === 'number' &&
       isFinite(value) &&
@@ -167,6 +168,7 @@
     var processing = false;
     var $form = document.querySelector('#form');
     var $recapchaInput = $form.querySelector('input[name=recaptcha]');
+    var $urlInput = $form.querySelector('input[name=url]');
     var $script = document.querySelector('#recaptcha');
     var recaptchaKey = null;
 
@@ -196,6 +198,15 @@
       }
     }
 
+    function getData() {
+      var data = {};
+      data.url = $urlInput.value.trim();
+      if (recaptchaKey) {
+        data.recaptcha = $recapchaInput.value;
+      }
+      return data;
+    }
+
     function handleSubmit(e) {
       e.preventDefault();
       if (processing) {
@@ -220,15 +231,22 @@
           afterReceive(null, '로봇인증에 오류가 발생했습니다.', true);
         }).then(function() {
           return new Promise(function(resolve, reject) {
-            var formData = new FormData($form);
-            // ajax mock
-            setTimeout(function() {
-              if (Math.random() > 0.2) {
-                resolve('https://to2.kr/abc');
-              } else {
-                reject({ type: 'to2.kr-error', message: '에러 발생' });
+            var data = getData();
+            axios.post('/shorten', data).then(function(res) {
+              var shortenUrl = res.data.shortenUrl;
+              resolve(shortenUrl);
+            }, function(e) {
+              var res = e.response;
+              if (res.data.error) {
+                if (res.data.code = 'RECAPTCHA_INVALID') {
+                  return reject({ type: 'to2.kr-error', message: '사용자 로봇 검증에 에러가 발생했습니다.' });
+                }
               }
-            }, 1000);
+              
+              return reject(e);
+            }).catch(function(e) {
+              reject(e);
+            });
           });
         }).then(function(url) {
           afterReceive(url, '주소가 성공적으로 줄여졌습니다 복사해서 사용하세요 :)');
@@ -238,8 +256,9 @@
           } else {
             throw e;
           }
-        }).catch(function() {
+        }).catch(function(e) {
           afterReceive(null, '알 수 없는 에러가 발생했습니다.', true);
+          console.error('처리 불가한 에러', e);
         });
       }
     }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -52,7 +52,8 @@
     function handleInput() {
       var url = $input.value;
       if (url.length === 0) {
-        $box.classList.remove('correct', 'wrong');
+        $box.classList.remove('correct');
+        $box.classList.remove('wrong');
         status = 'none';
         return;
       }
@@ -87,8 +88,10 @@
       if (type !== 'success' && type !== 'error') {
         type = 'success';
       }
-      $message.classList.remove('success', 'error');
+      $message.classList.remove('success');
+      $message.classList.remove('error');
       $message.classList.add('show', type);
+      $message.classList.add(type);
       if (!Number.isInteger(time)) {
         time = 3000;
       }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -40,15 +40,15 @@
       <div id="result">
         <span id="shorten-url"></span>
         <svg id="clipboard" width="38" height="36" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <ellipse cx="19" cy="18" rx="18.0844" ry="17.904" fill="#FFE8CE"/>
+          <ellipse cx="19" cy="18" rx="18.0844" ry="17.904" fill="#FFE8CE"></ellipse>
           <g clip-path="url(#a)" stroke="#FF8600" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M26.3466 10.4921H11.6528v17.311h14.6938v-17.311Z" fill="#fff"/>
-            <path class="check" d="m16.0063 18.5982 2.6129 2.9321 4.0071-4.1394"/>
-            <path d="M22.8994 8.80751h-7.7988v3.37799h7.7988V8.80751Z" fill="#FFD5A7"/>
+            <path d="M26.3466 10.4921H11.6528v17.311h14.6938v-17.311Z" fill="#fff"></path>
+            <path class="check" d="m16.0063 18.5982 2.6129 2.9321 4.0071-4.1394"></path>
+            <path d="M22.8994 8.80751h-7.7988v3.37799h7.7988V8.80751Z" fill="#FFD5A7"></path>
           </g>
           <defs>
             <clipPath id="a">
-              <path fill="#fff" transform="translate(10 7.10971)" d="M0 0h18v21.7806H0z"/>
+              <path fill="#fff" transform="translate(10 7.10971)" d="M0 0h18v21.7806H0z"></path>
             </clipPath>
           </defs>
         </svg>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -64,6 +64,7 @@
     <script id="recaptcha"
       th:if="${@recaptchaProperties.isActive()}"
       th:src="|https://www.google.com/recaptcha/api.js?render=${@recaptchaProperties.getSiteKey()}|"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script th:src="@{/js/app.js}"></script>
   </main>
 </body>


### PR DESCRIPTION
## 작업 내역
- `To2Service`, `RecaptchaService` service interface(gateway) 작성
- `To2Service`, `RecaptchaService` 더미 구현체 작성
- IE 호환 코드 작업
- #9 에 언급된 Controller API 작성
- axios를 사용한 ajax 연결
- 에러 처리 코드 작성

## 코드리뷰 주의사항

혹시 js코드를 es5로 작성하는 것에 의문을 가지실 수 있으나 이는 ie를 지원하기 위해서 그렇습니다.
추후 client 코드를 분리하게 되면 문제(그냥 불편함)는 해결됩니다.

Service를 interface와 구현체로 나눠서 작성한 이유는 이후 TDD 코드 작성시 Mock을 하기 위해서 그렇습니다.

기존 PHP 프로젝트에서는 내부 DB에 기록을 잡기위해서 302 redirect를 했습니다.
그러나 이번 프로젝트에서는 301로 변경했습니다.
혹시 다른 의견 있으시면 말씀해주세요.

## 이후 필요 작업
- DB 모델링 및 연결
- `To2Service` 디비와 연결
- `RecaptchaService` 실제 google api 연결
- 에러 핸들링 코드 작성

Closes #9